### PR TITLE
types/struct: rewrite interface, change `unknown` default

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,11 @@ struct<name, members...>
 
 #### Example
 ``` nix
-korora.struct "myStruct" {
-  foo = types.string;
+korora.struct {
+  name = "myStruct";
+  types = {
+    foo = types.string;
+  };
 }
 ```
 
@@ -235,9 +238,12 @@ korora.struct "myStruct" {
 
 By default, all attribute names must be present in a struct. It is possible to override this by specifying _totality_. Here is how to do this:
 ``` nix
-(korora.struct "myStruct" {
-  foo = types.string;
-}).override { total = false; }
+korora.struct {
+  name = "myStruct";
+  types = {
+    foo = types.string;
+  };
+}
 ```
 
 This means that a `myStruct` struct can have any of the keys omitted. Thus these are valid:
@@ -252,11 +258,15 @@ in ...
 
 By default, unknown attribute names are allowed.
 
-It is possible to override this by specifying `unknown`.
-``` nix
-(korora.struct "myStruct" {
-  foo = types.string;
-}).override { unknown = false; }
+It is possible to override this by specifying `unknown` on struct creation:
+```nix
+korora.struct {
+  name = "myStruct";
+  unknown = false;
+  types = {
+    foo = types.string;
+  };
+}
 ```
 
 This means that
@@ -275,24 +285,57 @@ allocation this function allocates one intermediate attribute set per struct ver
 
 Custom struct verification functions can be added as such:
 ``` nix
-(types.struct "testStruct2" {
-  x = types.int;
-  y = types.int;
-}).override {
+korora.struct {
+  name = "testStruct2";
   verify = v: if v.x + v.y == 2 then "VERBOTEN" else null;
-};
+  types = {
+    x = types.int;
+    y = types.int;
+  };
+}
 ```
+
+- Overridability
+
+An existing struct can have its behavior changed, by using `.override` like so:
+```nix
+let
+  # total is true by default
+  myStruct = korora.struct {
+    name = "myStruct";
+    types = {
+      foo = types.string;
+    };
+  };
+in
+  myStruct.override { total = false; }
+```
+
+This allows overriding `total`, `unknown`, and `verify` after the fact.
 
 #### Function signature
 
-`name`
+structured function argument
 
-: Name of struct type as a string
+: `name`
 
+  : Function argument
 
-`members`
+  `types`
 
-: Attribute set of type definitions.
+  : Name of struct type as a strng
+
+  `total`
+
+  : Attribute set of type definitions
+
+  `unknown`
+
+  : Function argument
+
+  `verify`
+
+  : Function argument
 
 
 ## `lib.types.optionalAttr`

--- a/README.md
+++ b/README.md
@@ -256,13 +256,13 @@ in ...
 
 - Unknown attribute names
 
-By default, unknown attribute names are allowed.
+By default, unknown attribute names are not allowed.
 
 It is possible to override this by specifying `unknown` on struct creation:
 ```nix
 korora.struct {
   name = "myStruct";
-  unknown = false;
+  unknown = true;
   types = {
     foo = types.string;
   };
@@ -276,7 +276,7 @@ This means that
   baz = "hello";
 }
 ```
-is normally valid, but not when `unknown` is set to `false`.
+is normally invalid, but works when `unknown` is set to `true`.
 
 Because Nix lacks primitive operations to iterate over attribute sets dynamically without
 allocation this function allocates one intermediate attribute set per struct verification.
@@ -315,27 +315,9 @@ This allows overriding `total`, `unknown`, and `verify` after the fact.
 
 #### Function signature
 
-structured function argument
+`args`
 
-: `name`
-
-  : Function argument
-
-  `types`
-
-  : Name of struct type as a strng
-
-  `total`
-
-  : Attribute set of type definitions
-
-  `unknown`
-
-  : Function argument
-
-  `verify`
-
-  : Function argument
+: Function argument
 
 
 ## `lib.types.optionalAttr`

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 # Previously nixpkgs lib was required for import.
 # This retains the same interface.
-builtins.warn ''
+(builtins.warn or builtins.trace) ''
   Importing korora through the default.nix entrypoint is deprecated.
   Instead import it through types.nix without passing any function arguments:
 

--- a/tests.nix
+++ b/tests.nix
@@ -388,7 +388,7 @@ lib.fix (
         };
 
         testStructNonTotal = testStruct.override { total = false; };
-        testStructWithoutUnknown = testStruct.override { unknown = false; };
+        testStructWithUnknown = testStruct.override { unknown = true; };
         testStructNewVerify = testStruct2.override {
           verify = v: if v.x + v.y == 3 then "VERBOTEN" else null;
         };
@@ -414,10 +414,7 @@ lib.fix (
         };
 
         testNonTotal = {
-          expr = testStructNonTotal.verify {
-            foo = "bar";
-            unknown = "is allowed";
-          };
+          expr = testStructNonTotal.verify {};
           expected = null;
         };
 
@@ -446,15 +443,14 @@ lib.fix (
         };
 
         testUnknownAttrNotAllowed = {
-          expr = testStructWithoutUnknown.verify {
+          expr = testStruct.verify {
             foo = "bar";
             bar = "foo";
           };
           expected = "in struct 'testStruct': keys ['bar'] are unrecognized, expected keys are ['foo']";
         };
-
         testUnknownAttr = {
-          expr = testStruct.verify {
+          expr = testStructWithUnknown.verify {
             foo = "bar";
             bar = "foo";
           };

--- a/types.nix
+++ b/types.nix
@@ -363,13 +363,13 @@ fix (self: {
 
     - Unknown attribute names
 
-    By default, unknown attribute names are allowed.
+    By default, unknown attribute names are not allowed.
 
     It is possible to override this by specifying `unknown` on struct creation:
     ```nix
     korora.struct {
       name = "myStruct";
-      unknown = false;
+      unknown = true;
       types = {
         foo = types.string;
       };
@@ -383,7 +383,7 @@ fix (self: {
       baz = "hello";
     }
     ```
-    is normally valid, but not when `unknown` is set to `false`.
+    is normally invalid, but works when `unknown` is set to `true`.
 
     Because Nix lacks primitive operations to iterate over attribute sets dynamically without
     allocation this function allocates one intermediate attribute set per struct verification.
@@ -427,7 +427,7 @@ fix (self: {
       name, # Name of struct type as a strng
       types, # Attribute set of type definitions
       total ? true,
-      unknown ? true,
+      unknown ? false,
       verify ? null,
     }:
     assert isAttrs types;
@@ -438,7 +438,7 @@ fix (self: {
       mkStruct' =
         {
           total ? true,
-          unknown ? true,
+          unknown ? false,
           verify ? null,
         }:
         assert isBool total;


### PR DESCRIPTION
I think this makes structs easier to work with. Drafting because this doesn't have a nice error for people who used the old interface yet.