### PR TITLE
Literal types and refinements

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,11 @@ struct<name, members...>
 
 #### Example
 ``` nix
-korora.struct "myStruct" {
-  foo = types.string;
+korora.struct {
+  name = "myStruct";
+  types = {
+    foo = types.string;
+  };
 }
 ```
 
@@ -235,9 +238,12 @@ korora.struct "myStruct" {
 
 By default, all attribute names must be present in a struct. It is possible to override this by specifying _totality_. Here is how to do this:
 ``` nix
-(korora.struct "myStruct" {
-  foo = types.string;
-}).override { total = false; }
+korora.struct {
+  name = "myStruct";
+  types = {
+    foo = types.string;
+  };
+}
 ```
 
 This means that a `myStruct` struct can have any of the keys omitted. Thus these are valid:
@@ -252,11 +258,15 @@ in ...
 
 By default, unknown attribute names are allowed.
 
-It is possible to override this by specifying `unknown`.
-``` nix
-(korora.struct "myStruct" {
-  foo = types.string;
-}).override { unknown = false; }
+It is possible to override this by specifying `unknown` on struct creation:
+```nix
+korora.struct {
+  name = "myStruct";
+  unknown = false;
+  types = {
+    foo = types.string;
+  };
+}
 ```
 
 This means that
@@ -275,24 +285,57 @@ allocation this function allocates one intermediate attribute set per struct ver
 
 Custom struct verification functions can be added as such:
 ``` nix
-(types.struct "testStruct2" {
-  x = types.int;
-  y = types.int;
-}).override {
+korora.struct {
+  name = "testStruct2";
   verify = v: if v.x + v.y == 2 then "VERBOTEN" else null;
-};
+  types = {
+    x = types.int;
+    y = types.int;
+  };
+}
 ```
+
+- Overridability
+
+An existing struct can have its behavior changed, by using `.override` like so:
+```nix
+let
+  # total is true by default
+  myStruct = korora.struct {
+    name = "myStruct";
+    types = {
+      foo = types.string;
+    };
+  };
+in
+  myStruct.override { total = false; }
+```
+
+This allows overriding `total`, `unknown`, and `verify` after the fact.
 
 #### Function signature
 
-`name`
+structured function argument
 
-: Name of struct type as a string
+: `name`
 
+  : Function argument
 
-`members`
+  `types`
 
-: Attribute set of type definitions.
+  : Name of struct type as a strng
+
+  `total`
+
+  : Attribute set of type definitions
+
+  `unknown`
+
+  : Function argument
+
+  `verify`
+
+  : Function argument
 
 
 ## `lib.types.optionalAttr`

--- a/README.md
+++ b/README.md
@@ -256,13 +256,13 @@ in ...
 
 - Unknown attribute names
 
-By default, unknown attribute names are allowed.
+By default, unknown attribute names are not allowed.
 
 It is possible to override this by specifying `unknown` on struct creation:
 ```nix
 korora.struct {
   name = "myStruct";
-  unknown = false;
+  unknown = true;
   types = {
     foo = types.string;
   };
@@ -276,7 +276,7 @@ This means that
   baz = "hello";
 }
 ```
-is normally valid, but not when `unknown` is set to `false`.
+is normally invalid, but works when `unknown` is set to `true`.
 
 Because Nix lacks primitive operations to iterate over attribute sets dynamically without
 allocation this function allocates one intermediate attribute set per struct verification.
@@ -315,27 +315,9 @@ This allows overriding `total`, `unknown`, and `verify` after the fact.
 
 #### Function signature
 
-structured function argument
+`args`
 
-: `name`
-
-  : Function argument
-
-  `types`
-
-  : Name of struct type as a strng
-
-  `total`
-
-  : Attribute set of type definitions
-
-  `unknown`
-
-  : Function argument
-
-  `verify`
-
-  : Function argument
+: Function argument
 
 
 ## `lib.types.optionalAttr`

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 # Previously nixpkgs lib was required for import.
 # This retains the same interface.
-builtins.warn ''
+(builtins.warn or builtins.trace) ''
   Importing korora through the default.nix entrypoint is deprecated.
   Instead import it through types.nix without passing any function arguments:
 

--- a/default.nix
+++ b/default.nix
@@ -1,10 +1,1 @@
-# Previously nixpkgs lib was required for import.
-# This retains the same interface.
-(builtins.warn or builtins.trace) ''
-  Importing korora through the default.nix entrypoint is deprecated.
-  Instead import it through types.nix without passing any function arguments:
-
-  korora = import inputs.korora { inherit lib; };
-  ->
-  korora = import "''${inputs.korora}/types.nix"
-'' (_: import ./types.nix)
+import ./types.nix

--- a/lib.nix
+++ b/lib.nix
@@ -67,59 +67,9 @@ let
     # Regex from https://github.com/NixOS/nix/blob/d048577909e383439c2549e849c5c2f2016c997e/src/libexpr/lexer.l#L91
     if match "[a-zA-Z_][a-zA-Z0-9_'-]*" s != null then s else escapeNixString s;
 
-  /**
-    “right fold” a binary function `op` between successive elements of
-    `list` with `nul` as the starting value, i.e.,
-    `foldr op nul [x_1 x_2 ... x_n] == op x_1 (op x_2 ... (op x_n nul))`.
-
-    # Inputs
-
-    `op`
-
-    : 1\. Function argument
-
-    `nul`
-
-    : 2\. Function argument
-
-    `list`
-
-    : 3\. Function argument
-
-    # Type
-
-    ```
-    foldr :: (a -> b -> b) -> b -> [a] -> b
-    ```
-
-    # Examples
-    :::{.example}
-    ## `lib.lists.foldr` usage example
-
-    ```nix
-    concat = foldr (a: b: a + b) "z"
-    concat [ "a" "b" "c" ]
-    => "abcz"
-    # different types
-    strange = foldr (int: str: toString (int + 1) + str) "a"
-    strange [ 1 2 3 4 ]
-    => "2345a"
-    ```
-
-    :::
-  */
-  foldr =
-    op: nul: list:
-    let
-      len = length list;
-      fold' = n: if n == len then nul else op (elemAt list n) (fold' (n + 1));
-    in
-    fold' 0;
 in
 
 {
-  inherit foldr;
-
   /**
     Pretty print a value, akin to `builtins.trace`.
 

--- a/lib.nix
+++ b/lib.nix
@@ -67,9 +67,58 @@ let
     # Regex from https://github.com/NixOS/nix/blob/d048577909e383439c2549e849c5c2f2016c997e/src/libexpr/lexer.l#L91
     if match "[a-zA-Z_][a-zA-Z0-9_'-]*" s != null then s else escapeNixString s;
 
+  /**
+    “right fold” a binary function `op` between successive elements of
+    `list` with `nul` as the starting value, i.e.,
+    `foldr op nul [x_1 x_2 ... x_n] == op x_1 (op x_2 ... (op x_n nul))`.
+
+    # Inputs
+
+    `op`
+
+    : 1\. Function argument
+
+    `nul`
+
+    : 2\. Function argument
+
+    `list`
+
+    : 3\. Function argument
+
+    # Type
+
+    ```
+    foldr :: (a -> b -> b) -> b -> [a] -> b
+    ```
+
+    # Examples
+    :::{.example}
+    ## `lib.lists.foldr` usage example
+
+    ```nix
+    concat = foldr (a: b: a + b) "z"
+    concat [ "a" "b" "c" ]
+    => "abcz"
+    # different types
+    strange = foldr (int: str: toString (int + 1) + str) "a"
+    strange [ 1 2 3 4 ]
+    => "2345a"
+    ```
+
+    :::
+  */
+  foldr =
+    op: nul: list:
+    let
+      len = length list;
+      fold' = n: if n == len then nul else op (elemAt list n) (fold' (n + 1));
+    in
+    fold' 0;
 in
 
 {
+  inherit foldr;
 
   /**
     Pretty print a value, akin to `builtins.trace`.

--- a/tests.nix
+++ b/tests.nix
@@ -388,7 +388,7 @@ lib.fix (
         };
 
         testStructNonTotal = testStruct.override { total = false; };
-        testStructWithoutUnknown = testStruct.override { unknown = false; };
+        testStructWithUnknown = testStruct.override { unknown = true; };
         testStructNewVerify = testStruct2.override {
           verify = v: if v.x + v.y == 3 then "VERBOTEN" else null;
         };
@@ -414,10 +414,7 @@ lib.fix (
         };
 
         testNonTotal = {
-          expr = testStructNonTotal.verify {
-            foo = "bar";
-            unknown = "is allowed";
-          };
+          expr = testStructNonTotal.verify {};
           expected = null;
         };
 
@@ -446,15 +443,14 @@ lib.fix (
         };
 
         testUnknownAttrNotAllowed = {
-          expr = testStructWithoutUnknown.verify {
+          expr = testStruct.verify {
             foo = "bar";
             bar = "foo";
           };
           expected = "in struct 'testStruct': keys ['bar'] are unrecognized, expected keys are ['foo']";
         };
-
         testUnknownAttr = {
-          expr = testStruct.verify {
+          expr = testStructWithUnknown.verify {
             foo = "bar";
             bar = "foo";
           };

--- a/tests.nix
+++ b/tests.nix
@@ -651,6 +651,15 @@ lib.fix (
             expr = fn "foo";
             expectedError.type = "ThrownError";
           };
+
+        testTwoArgsOk =
+          let
+            fn = types.defun "fn" [ types.str types.int ] types.int (_: _: 2);
+          in
+          {
+            expr = fn "arg1" 2;
+            expected = 2;
+          };
       };
 
     recursiveTypes = {

--- a/tests.nix
+++ b/tests.nix
@@ -30,6 +30,34 @@ in
 lib.fix (
   self:
   addCoverage types {
+    from = {
+      simple =
+        let type = types.from "0"; in {
+          testValid = { expr = type.verify "0"; expected = null; };
+          testNotValid = { expr = type.verify "1"; expected = "Expected string '\"0\"' but got string '\"1\"'"; };
+        };
+      complex =
+        let type = types.from [ "0" 1 false ]; in {
+          testValid = { expr = type.verify [ "0" 1 false ]; expected = null; };
+          testNotValid = { expr = type.verify [ "0" 1 true ]; expected = "in tuple<0, 1, false>: in element 2: Expected bool 'false' but got bool 'true'"; };
+        };
+    };
+
+    scalar = {
+      int = let type = types.scalar.int 0; in {
+        testValid = { expr = type.verify 0; expected = null; };
+        testNotValid = { expr = type.verify 1; expected = "Expected int '0' but got int '1'"; };
+      };
+      string = let type = types.scalar.string 0; in {
+        testValid = { expr = type.verify 0; expected = null; };
+        testNotValid = { expr = type.verify 1; expected = "Expected string '0' but got int '1'"; };
+      };
+      float = let type = types.scalar.float 0.0; in {
+        testValid = { expr = type.verify 0.0; expected = null; };
+        testNotValid = { expr = type.verify 1.0; expected = "Expected float '0.0' but got float '1.0'"; };
+      };
+    };
+
     string = {
       testInvalid = {
         expr = types.str.verify 1;

--- a/tests.nix
+++ b/tests.nix
@@ -652,6 +652,15 @@ lib.fix (
             expectedError.type = "ThrownError";
           };
 
+        testDifferingReturnOk =
+          let
+            fn = types.defun "fn" [ types.str types.int ] types.bool (_: _: true);
+          in
+          {
+            expr = fn "arg1" 2;
+            expected = true;
+          };
+
         testTwoArgsOk =
           let
             fn = types.defun "fn" [ types.str types.int ] types.int (_: _: 2);

--- a/tests.nix
+++ b/tests.nix
@@ -725,5 +725,58 @@ lib.fix (
           };
         };
     };
+
+    record =
+      let type = types.record "t" { x = types.int; }; in {
+      testOK = {
+        expr = type.verify { x = 0; };
+        expected = null;
+      };
+      testNotOK = {
+        expr = type.check { x = "no"; } null;
+        expectedError.type = "ThrownError";
+      };
+    };
+
+    omit = {
+      simple =
+        let type = types.omit (types.record "aaa" { x = types.int; }); in
+        {
+          testOK = {
+            expr = type.verify 0;
+            expected = null;
+          };
+          test2OK = {
+            expr = type.verify "asdf";
+            expected = null;
+          };
+          test3OK = {
+            expr = type.verify { x = "asdf"; };
+            expected = null;
+          };
+          testNotOK = {
+            expr = type.verify { x = 0; };
+            expected = "aaa forbidden";
+          };
+        };
+
+      complex =
+        let
+          type = types.intersection [
+            (types.record "xint" { x = types.union [ types.int types.str ]; })
+            (types.omit (types.record "xint" { x = types.int; }))
+          ];
+        in
+        {
+          testOK = {
+            expr = type.verify { x = "hello"; };
+            expected = null;
+          };
+          testNotOK = {
+            expr = type.verify { x = 32; };
+            expected = "Expected type 'intersection<xint,omit<xint>>' but value '{\n    x = 32;\n  }' is of type 'set'";
+          };
+        };
+    };
   }
 )

--- a/tests.nix
+++ b/tests.nix
@@ -58,6 +58,20 @@ lib.fix (
       };
     };
 
+    refine =
+      let type = types.refine "GreaterThanFour" types.int (n: n > 4);  in
+      {
+        testValid = { expr = type.verify 5; expected = null; };
+        testNotValid = { expr = type.verify 3; expected = "failed predicate GreaterThanFour"; };
+      };
+
+    refine' =
+      let type = types.refine' "GreaterThanFour" types.int (n: if n > 4 then null else "not greater than four"); in
+      {
+        testValid = { expr = type.verify 5; expected = null; };
+        testNotValid = { expr = type.verify 3; expected = "not greater than four"; };
+      };
+
     string = {
       testInvalid = {
         expr = types.str.verify 1;

--- a/types.nix
+++ b/types.nix
@@ -363,13 +363,13 @@ fix (self: {
 
     - Unknown attribute names
 
-    By default, unknown attribute names are allowed.
+    By default, unknown attribute names are not allowed.
 
     It is possible to override this by specifying `unknown` on struct creation:
     ```nix
     korora.struct {
       name = "myStruct";
-      unknown = false;
+      unknown = true;
       types = {
         foo = types.string;
       };
@@ -383,7 +383,7 @@ fix (self: {
       baz = "hello";
     }
     ```
-    is normally valid, but not when `unknown` is set to `false`.
+    is normally invalid, but works when `unknown` is set to `true`.
 
     Because Nix lacks primitive operations to iterate over attribute sets dynamically without
     allocation this function allocates one intermediate attribute set per struct verification.
@@ -427,7 +427,7 @@ fix (self: {
       name, # Name of struct type as a strng
       types, # Attribute set of type definitions
       total ? true,
-      unknown ? true,
+      unknown ? false,
       verify ? null,
     }:
     assert isAttrs types;
@@ -438,7 +438,7 @@ fix (self: {
       mkStruct' =
         {
           total ? true,
-          unknown ? true,
+          unknown ? false,
           verify ? null,
         }:
         assert isBool total;

--- a/types.nix
+++ b/types.nix
@@ -76,6 +76,7 @@ let
     elemAt
     length
     genList
+    mapAttrs
     ;
 
   isDerivation = value: isAttrs value && (value.type or null == "derivation");
@@ -85,6 +86,10 @@ let
   joinKeys = list: concatStringsSep ", " (map (e: "'${e}'") list);
 
   toPretty = (import ./lib.nix).toPretty { indent = "    "; };
+
+  concatMapAttrsStringSep =
+    sep: f: attrs:
+    concatStringsSep sep (attrValues (mapAttrs f attrs));
 
   typeError = name: v: "Expected type '${name}' but value '${toPretty v}' is of type '${typeOf v}'";
 
@@ -113,6 +118,15 @@ let
       );
 
   addErrorContext = context: error: if error == null then null else "${context}: ${error}";
+
+  scalarName = {
+    int = toString;
+    bool = v: if v then "true" else "false";
+    string = toString;
+    path = toString;
+    null = toString;
+    float = toString;
+  };
 
   fix =
     f:
@@ -545,6 +559,55 @@ fix (self: {
         withErrorContext (verifyValue v 0)
     );
 
+  /*
+    scalar.int
+    scalar.bool
+    scalar.string
+    scalar.path
+    scalar.null
+    scalar.float
+
+    Attrset of types to check functions (returns bool for success) that a scalar
+    literal matches for that type
+   */
+  scalar = mapAttrs (k: checkFn: type:
+    self.typedef'
+      (scalarName.${k} type)
+      (v: if checkFn type v then null else "Expected ${k} '${toPretty type}' but got ${typeOf v} '${toPretty v}'")
+  ) {
+    int = type: value: type == value;
+    bool = type: value: type == value;
+    string = type: value: type == value;
+    path = type: value: type == value;
+    null = type: value: type == value;
+    float = type: value: type == value;
+  };
+
+  /*
+    from<value>
+
+    Build a type from a literal input
+  */
+  from = value:
+    if value ? name then
+      value
+    else
+      let t = typeOf value; in
+      if self.scalar ? ${t} then
+        self.scalar.${t} value
+      else if t == "lambda" then
+        self.typedef' "lambda" (v: (self.from (value v)).verify)
+      else if t == "set" then
+        let
+          value_ = mapAttrs (_: self.from) value;
+        in
+        (self.struct
+          "{${concatMapAttrsStringSep ";" (k: v: "${k}=${v.name}}") value_}"
+          value_).override { total = true; unknown = false; }
+      else if t == "list" then
+        self.tuple (map self.from value)
+      else
+        throw "check: cannot handle ${value} :: ${t}";
   /*
     Create a wrapped type checked function.
   */

--- a/types.nix
+++ b/types.nix
@@ -341,6 +341,22 @@ fix (self: {
     );
 
   /*
+    map<k, t>
+  */
+  map =
+    # Attribute value type
+    k: v:
+    let
+      name = "map<${k.name}, ${v.name}>";
+      withErrorContext = addErrorContext "in ${name} value";
+    in
+    self.typedef' name (v:
+      if !isAttrs v then
+        typeError name v
+      else
+        withErrorContext (all' k.verify (attrNames v) && all' v.verify (attrValues v))
+    );
+  /*
     union<types...>
   */
   union =

--- a/types.nix
+++ b/types.nix
@@ -608,6 +608,25 @@ fix (self: {
         self.tuple (map self.from value)
       else
         throw "check: cannot handle ${value} :: ${t}";
+
+  /*
+    refine'<name, T, refinement>
+
+    Create a refinement over a given verify function
+  */
+  refine' =
+    name: T: refinement:
+    self.typedef' name (v:
+      let err1 = T.verify v; in
+      if err1 == null then
+        refinement v
+      else
+        err1);
+  
+  /* Create a refinement over a given check function */
+  refine = name: T: predicate: self.refine' name T
+    (v: if predicate v then null else "failed predicate ${name}");
+
   /*
     Create a wrapped type checked function.
   */

--- a/types.nix
+++ b/types.nix
@@ -79,7 +79,6 @@ let
     mapAttrs
     stringLength
     match
-    tail
     ;
 
   isDerivation = value: isAttrs value && (value.type or null == "derivation");
@@ -88,7 +87,9 @@ let
 
   joinKeys = list: concatStringsSep ", " (map (e: "'${e}'") list);
 
-  toPretty = (import ./lib.nix).toPretty { indent = "  "; };
+  lib = import ./lib.nix;
+  toPretty = lib.toPretty {indent = "  ";};
+  inherit (lib) foldr;
 
   concatMapAttrsStringSep =
     sep: f: attrs:
@@ -789,26 +790,21 @@ fix (self: {
     name: args: T: f:
     let
       errorPrefix = "while calling '${name}'";
-    in
-    foldl'
-      (
-        fun: idx:
-        let
-          type = elemAt args idx;
-        in
-        value:
-        if type.verify value != null then
-          throw "${errorPrefix}: while checking argument ${toString idx}: ${type.verify value}"
+      len = length args;
+      run = idx: partial:
+        if idx < len then
+          arg:
+          let err = (elemAt args idx).verify arg; in
+          if err != null then
+            throw "${errorPrefix}: while checking argument ${toString idx}: ${err}"
+          else
+            run (idx + 1) (partial arg)
         else
-          fun value
-      )
-      (
-        arg:
-        let
-          value = f arg;
-          err = T.verify value;
-        in
-        if err != null then throw "${errorPrefix}: while checking return type: ${err}" else value
-      )
-      (genList (i: i) (length args));
+          let err = T.verify partial; in
+          if err != null then
+            throw "${errorPrefix}: while checking return type: ${err}"
+          else
+            partial;
+    in
+      run 0 f;
 })

--- a/types.nix
+++ b/types.nix
@@ -77,6 +77,9 @@ let
     length
     genList
     mapAttrs
+    stringLength
+    match
+    tail
     ;
 
   isDerivation = value: isAttrs value && (value.type or null == "derivation");
@@ -135,6 +138,8 @@ let
     in
     x;
 
+
+  isType = t: t ? __name && isString t;
 in
 fix (self: {
 
@@ -173,7 +178,17 @@ fix (self: {
   /*
     String
   */
-  string = self.typedef "string" isString;
+  string = self.typedef "string" isString // {
+    match = regex: self.refine "/${regex}/" self.string (s: match regex s != null);
+    size = {
+      nonEmpty = self.refine "non-empty" self.string (s: s != "");
+      lt = len: self.refine "length<${toString len}" self.string (s: stringLength s < len);
+      gt = len: self.refine "length>${toString len}" self.string (s: stringLength s > len);
+      lte = len: self.refine "length<${toString len}" self.string (s: stringLength s < len);
+      gte = len: self.refine "length>${toString len}" self.string (s: stringLength s > len);
+      between = a: b: self.refine "${toString a}<=length<=${toString b}" self.string (s: a <= stringLength s && stringLength s <= b);
+    };
+  };
 
   /*
     Type alias for string
@@ -193,17 +208,46 @@ fix (self: {
   /*
     Int
   */
-  int = self.typedef "int" isInt;
+  int = self.typedef "int" isInt // {
+    lt = len: self.refine "int<${toString len}" self.int (s: s < len);
+    gt = len: self.refine "int>${toString len}" self.int (s: s > len);
+    lte = len: self.refine "int<${toString len}" self.int (s: s < len);
+    gte = len: self.refine "int>${toString len}" self.int (s: s > len);
+    between = a: b: self.refine "${toString a}<=int<=${toString b}" self.int (s: a <= s && s <= b);
+    even = self.refine "even" self.int (n: n == (n / 2) * 2);
+    odd = self.refine "odd" self.int (n: n != (n / 2) * 2);
+    positive = self.refine "positive" self.int (n: n > 0);
+    nonNegative = self.refine "nonNegative" self.int (n: n >= 0);
+    negative = self.refine "positive" self.int (n: n < 0);
+  };
 
   /*
     Single precision floating point
   */
-  float = self.typedef "float" isFloat;
+  float = self.typedef "float" isFloat // {
+    lt = len: self.refine "float<${toString len}" self.float (s: s < len);
+    gt = len: self.refine "float>${toString len}" self.float (s: s > len);
+    lte = len: self.refine "float<${toString len}" self.float (s: s < len);
+    gte = len: self.refine "float>${toString len}" self.float (s: s > len);
+    between = a: b: self.refine "${toString a}<=float<=${toString b}" self.float (s: a <= s && s <= b);
+    positive = self.refine "positive" self.float (n: n > 0.0);
+    nonNegative = self.refine "nonNegative" self.float (n: n >= 0.0);
+    negative = self.refine "positive" self.float (n: n < 0.0);
+  };
 
   /*
     Either an int or a float
   */
-  number = self.typedef "number" (v: isInt v || isFloat v);
+  number = self.typedef "number" (v: isInt v || isFloat v) // {
+    lt = len: self.refine "number<${toString len}" self.number (s: s < len);
+    gt = len: self.refine "number>${toString len}" self.number (s: s > len);
+    lte = len: self.refine "number<${toString len}" self.number (s: s < len);
+    gte = len: self.refine "number>${toString len}" self.number (s: s > len);
+    between = a: b: self.refine "${toString a}<=number<=${toString b}" self.number (s: a <= s && s <= b);
+    positive = self.refine "positive" self.number (n: n > 0);
+    nonNegative = self.refine "nonNegative" self.number (n: n >= 0);
+    negative = self.refine "positive" self.number (n: n < 0);
+  };
 
   /*
     Bool
@@ -561,6 +605,37 @@ fix (self: {
       in
       mkStruct' { inherit total unknown verify; };
 
+
+  /*
+    Another interface for defining records
+
+    record<name, types> - strict record; no unknown elements
+    record.partial<name, types> - record which allows missing keys
+    record.extensible<name, types> - record which allows unknown keys
+    record.loose<name, types> - record which allows missing keys and unknown keys
+  */
+  record = {
+    __functor = _: name: types: self.struct {
+      inherit name types;
+      total = true;
+      unknown = false;
+    };
+    partial = name: types: self.struct {
+      inherit name types;
+      total = false;
+      unknown = false;
+    };
+    extensible = name: types: self.struct {
+      inherit name types;
+      total = true;
+      unknown = true;
+    };
+    loose = name: types: self.struct {
+      inherit name types;
+      total = false;
+      unknown = false;
+    };
+  };
   /*
     optionalAttr<t>
   */
@@ -677,16 +752,19 @@ fix (self: {
   */
   refine' =
     name: T: refinement:
-    self.typedef' name (v:
-      let err1 = T.verify v; in
-      if err1 == null then
-        refinement v
-      else
-        err1);
-  
-  /* Create a refinement over a given check function */
-  refine = name: T: predicate: self.refine' name T
-    (v: if predicate v then null else "failed predicate ${name}");
+    self.typedef' name (v: let err1 = T.verify v; in if err1 == null then refinement v else err1);
+
+  /*
+    Create a refinement over a given check function
+  */
+  refine = name: T: predicate:
+    self.refine' name T (v: if predicate v then null else "failed predicate ${name}");
+
+  /*
+    Refuse to accept the given type
+  */
+  omit = T:
+    self.typedef' "omit<${T.name}>" (v: let err = T.verify v; in if err == null then "${T.name} forbidden" else null);
 
   /*
     Create a wrapped type checked function.

--- a/types.nix
+++ b/types.nix
@@ -75,7 +75,6 @@ let
     foldl'
     elemAt
     length
-    genList
     mapAttrs
     stringLength
     match
@@ -89,7 +88,6 @@ let
 
   lib = import ./lib.nix;
   toPretty = lib.toPretty {indent = "  ";};
-  inherit (lib) foldr;
 
   concatMapAttrsStringSep =
     sep: f: attrs:


### PR DESCRIPTION
Happy to split into two PRs

Basically `t.from { ... }` can be treated as a "strict" struct, `t.from [...]` is `t.tuple`, and `t.from` anything else is verifies that literal thing for primitive/scalar types, or runs the function as if it's a verify function. It also recurses into the thing you pass it, so `t.from { x = { y = t.int; z = 5; }; }` is perfectly kosher. I implemented it to have lighter syntax when using this excellent library.

`t.refine` and `t.refine'` let you augment an existing type with a predicate. They're pretty much `typedef` but with nicer syntax.